### PR TITLE
Add SMTP username field and fix port 587 compatibility

### DIFF
--- a/newsletterr.py
+++ b/newsletterr.py
@@ -246,6 +246,7 @@ def init_db(db_path):
             from_email TEXT,
             alias_email TEXT,
             password TEXT,
+            smtp_username TEXT,
             smtp_server TEXT,
             smtp_port INTEGER,
             server_name TEXT,
@@ -333,6 +334,14 @@ def init_db(db_path):
     if 'date_range' not in columns:
         print("Adding date_range column to email_schedules table...")
         cursor.execute("ALTER TABLE email_schedules ADD COLUMN date_range INTEGER DEFAULT 7")
+        conn.commit()
+    
+    # Check if smtp_username column exists in settings table
+    cursor.execute("PRAGMA table_info(settings)")
+    settings_columns = [column[1] for column in cursor.fetchall()]
+    if 'smtp_username' not in settings_columns:
+        print("Adding smtp_username column to settings table...")
+        cursor.execute("ALTER TABLE settings ADD COLUMN smtp_username TEXT")
         conn.commit()
     
     conn.close()
@@ -1820,7 +1829,7 @@ def send_email():
     cursor = conn.cursor()
     cursor.execute("""
         SELECT
-        from_email, alias_email, password, smtp_server, smtp_port, server_name
+        from_email, alias_email, password, smtp_username, smtp_server, smtp_port, server_name
         FROM settings WHERE id = 1
     """)
     row = cursor.fetchone()
@@ -1831,9 +1840,10 @@ def send_email():
             "from_email": row[0] or "",
             "alias_email": row[1] or "",
             "password": row[2] or "",
-            "smtp_server": row[3] or "",
-            "smtp_port": int(row[4]) if row[4] is not None else 587,
-            "server_name": row[5] or ""
+            "smtp_username": row[3] or "",
+            "smtp_server": row[4] or "",
+            "smtp_port": int(row[5]) if row[5] is not None else 587,
+            "server_name": row[6] or ""
         }
     else:
         return jsonify({"error": "Please enter email info on settings page"}), 500
@@ -1855,6 +1865,7 @@ def send_email():
     from_email = settings['from_email']
     alias_email = settings['alias_email']
     password = settings['password']
+    smtp_username = settings['smtp_username']
     smtp_server = settings['smtp_server']
     smtp_port = int(settings['smtp_port'])
     server_name = settings['server_name']
@@ -1913,8 +1924,15 @@ def send_email():
         msg_root.attach(p)
 
     try:
-        with smtplib.SMTP_SSL(smtp_server, smtp_port) as server:
-            server.login(from_email, decrypt(password))
+        if int(smtp_port) == 465:
+            server = smtplib.SMTP_SSL(smtp_server, smtp_port)
+            login_username = smtp_username if smtp_username else from_email
+            server.login(login_username, decrypt(password))
+        else:
+            server = smtplib.SMTP(smtp_server, smtp_port)
+            server.starttls()
+            login_username = smtp_username if smtp_username else from_email
+            server.login(login_username, decrypt(password))
             
             email_content = msg_root.as_string()
             content_size_kb = len(email_content.encode('utf-8')) / 1024
@@ -1944,7 +1962,8 @@ def send_email():
                 history_conn.close()
             except Exception as history_error:
                 print(f"Error saving email history: {history_error}")
-            
+        
+        server.quit()
         return jsonify({"success": True})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -1958,6 +1977,7 @@ def settings():
         from_email = request.form.get("from_email")
         alias_email = request.form.get("alias_email")
         password = encrypt(request.form.get("password"))
+        smtp_username = request.form.get("smtp_username")
         smtp_server = request.form.get("smtp_server")
         smtp_port = int(request.form.get("smtp_port"))
         server_name = request.form.get("server_name")
@@ -1970,11 +1990,11 @@ def settings():
 
         cursor.execute("""
             INSERT INTO settings
-            (id, from_email, alias_email, password, smtp_server, smtp_port, server_name, plex_url, tautulli_url, tautulli_api, conjurr_url, logo_filename, logo_width)
-            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, from_email, alias_email, password, smtp_username, smtp_server, smtp_port, server_name, plex_url, tautulli_url, tautulli_api, conjurr_url, logo_filename, logo_width)
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (id) DO UPDATE
-            SET from_email = excluded.from_email, alias_email = excluded.alias_email, password = excluded.password, smtp_server = excluded.smtp_server, smtp_port = excluded.smtp_port, server_name = excluded.server_name, plex_url = excluded.plex_url, tautulli_url = excluded.tautulli_url, tautulli_api = excluded.tautulli_api, conjurr_url = excluded.conjurr_url, logo_filename = excluded.logo_filename, logo_width = excluded.logo_width
-        """, (from_email, alias_email, password, smtp_server, smtp_port, server_name, plex_url, tautulli_url, tautulli_api, conjurr_url, logo_filename, logo_width))
+            SET from_email = excluded.from_email, alias_email = excluded.alias_email, password = excluded.password, smtp_username = excluded.smtp_username, smtp_server = excluded.smtp_server, smtp_port = excluded.smtp_port, server_name = excluded.server_name, plex_url = excluded.plex_url, tautulli_url = excluded.tautulli_url, tautulli_api = excluded.tautulli_api, conjurr_url = excluded.conjurr_url, logo_filename = excluded.logo_filename, logo_width = excluded.logo_width
+        """, (from_email, alias_email, password, smtp_username, smtp_server, smtp_port, server_name, plex_url, tautulli_url, tautulli_api, conjurr_url, logo_filename, logo_width))
         conn.commit()
         cursor.execute("SELECT plex_token FROM settings WHERE id = 1")
         plex_token = cursor.fetchone()[0]
@@ -1984,6 +2004,7 @@ def settings():
             "from_email": from_email,
             "alias_email": alias_email,
             "password": decrypt(password),
+            "smtp_username": smtp_username,
             "smtp_server": smtp_server,
             "smtp_port": smtp_port,
             "server_name": server_name,
@@ -2002,6 +2023,7 @@ def settings():
         from_email = cursor.execute("SELECT from_email FROM settings WHERE id = 1").fetchone()[0]
         alias_email = cursor.execute("SELECT alias_email FROM settings WHERE id = 1").fetchone()[0]
         password = cursor.execute("SELECT password FROM settings WHERE id = 1").fetchone()[0]
+        smtp_username = cursor.execute("SELECT smtp_username FROM settings WHERE id = 1").fetchone()[0]
         smtp_server = cursor.execute("SELECT smtp_server FROM settings WHERE id = 1").fetchone()[0]
         smtp_port = cursor.execute("SELECT smtp_port FROM settings WHERE id = 1").fetchone()[0]
         server_name = cursor.execute("SELECT server_name FROM settings WHERE id = 1").fetchone()[0]
@@ -2016,6 +2038,7 @@ def settings():
         from_email = cursor.execute("SELECT from_email FROM settings WHERE id = 1").fetchone()
         alias_email = cursor.execute("SELECT alias_email FROM settings WHERE id = 1").fetchone()
         password = cursor.execute("SELECT password FROM settings WHERE id = 1").fetchone()
+        smtp_username = cursor.execute("SELECT smtp_username FROM settings WHERE id = 1").fetchone()
         smtp_server = cursor.execute("SELECT smtp_server FROM settings WHERE id = 1").fetchone()
         smtp_port = cursor.execute("SELECT smtp_port FROM settings WHERE id = 1").fetchone()
         server_name = cursor.execute("SELECT server_name FROM settings WHERE id = 1").fetchone()
@@ -2030,6 +2053,7 @@ def settings():
     settings = {
         "from_email": from_email or "",
         "alias_email": alias_email or "",
+        "smtp_username": smtp_username or "",
         "smtp_server": smtp_server or "",
         "server_name": server_name or "",
         "plex_url": plex_url or "",
@@ -2044,9 +2068,9 @@ def settings():
         print(password)
         settings["password"] = decrypt(password)
     if smtp_port == '' or smtp_port is None:
-        settings["smtp_port"] = 465
+        settings["smtp_port"] = 587
         cursor.execute("""
-            INSERT INTO settings (id, smtp_port) VALUES (1, 465)
+            INSERT INTO settings (id, smtp_port) VALUES (1, 587)
             ON CONFLICT (id) DO UPDATE
             SET smtp_port = excluded.smtp_port
         """)

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -42,6 +42,11 @@
                     {% if settings.password != "" %}value="{{ settings.password }}"{% endif %}
                     placeholder="Email Password or App Password" required><br><br>
 
+                <label for="smtp_username">SMTP Username (Optional):</label><br>
+                <input type="text" id="smtp_username" name="smtp_username"
+                    {% if settings.smtp_username != "" %}value="{{ settings.smtp_username }}"{% endif %}
+                    placeholder="Leave blank to use your email address"><br><br>
+
                 <label for="smtp_server">SMTP Server:</label><br>
                 <input type="text" id="smtp_server" name="smtp_server"
                     {% if settings.smtp_server != "" %}value="{{ settings.smtp_server }}"{% endif %}


### PR DESCRIPTION
This PR adds an optional SMTP username field and fixes compatibility with port 587 TLS/STARTTLS. Changes include: optional SMTP username field for services like Resend, proper SSL vs STARTTLS handling for different ports, default port change from 465 to 587, proper server cleanup, and database migration for existing installations.